### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const cameras = await detectCameras()
 
 const cam = cameras[0]
 
-await cam.init()
+await cam.open()
 
 await cam.get('model')
 // -> 'Lumix S5'


### PR DESCRIPTION
cam.init() function is not found.
cam.open() works.