### PR TITLE
Fix problem relating to exposure comp on Panasonic cam

### DIFF
--- a/core/src/TethrPTPUSB/TethrPanasonic.ts
+++ b/core/src/TethrPTPUSB/TethrPanasonic.ts
@@ -214,7 +214,7 @@ export class TethrPanasonic extends TethrPTPUSB {
 					thirds = !match1[3] ? 0 : match1[3] === ' 1/3' ? 1 : 2
 				}
 
-				const match2 = match1 && v.match(/^([+-]?)(1\/3|2\/3)$/)
+				const match2 = !match1 && v.match(/^([+-]?)(1\/3|2\/3)$/)
 
 				if (match2) {
 					negative = match2[1] === '-'


### PR DESCRIPTION
# Overview

I fixed a problem where some exposure compensation values ​​could not be applied on Panasonic cameras.

Specifically, I fixed a problem that made it impossible to apply `+1/3`, `+2/3`, `-1/3`, and `-2/3`.

After the fix, I verified that all exposure compensation values ​​from +5 to -5 can be applied to Lumix DC-G9M2.